### PR TITLE
Exposing very hacky Wasm httplib replacement

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,9 @@ set(TARGET_NAME webmacro)
 # DuckDB's extension distribution supports vcpkg. As such, dependencies can be added in ./vcpkg.json and then
 # used in cmake with find_package. Feel free to remove or replace with other dependencies.
 # Note that it should also be removed from vcpkg.json to prevent needlessly installing it..
-find_package(OpenSSL REQUIRED)
+if(NOT EMSCRIPTEN)
+  find_package(OpenSSL REQUIRED)
+endif()
 
 set(EXTENSION_NAME ${TARGET_NAME}_extension)
 set(LOADABLE_EXTENSION_NAME ${TARGET_NAME}_loadable_extension)
@@ -24,8 +26,10 @@ endif()
 build_static_extension(${TARGET_NAME} ${EXTENSION_SOURCES})
 build_loadable_extension(${TARGET_NAME} " " ${EXTENSION_SOURCES})
 
-target_link_libraries(${EXTENSION_NAME} OpenSSL::SSL OpenSSL::Crypto ${WIN_LIBS})
-target_link_libraries(${LOADABLE_EXTENSION_NAME} OpenSSL::SSL OpenSSL::Crypto ${WIN_LIBS})
+if(NOT EMSCRIPTEN)
+  target_link_libraries(${EXTENSION_NAME} OpenSSL::SSL OpenSSL::Crypto ${WIN_LIBS})
+  target_link_libraries(${LOADABLE_EXTENSION_NAME} OpenSSL::SSL OpenSSL::Crypto ${WIN_LIBS})
+endif()
 
 install(
   TARGETS ${EXTENSION_NAME}

--- a/src/include/wasm_httplib_replacement.hpp
+++ b/src/include/wasm_httplib_replacement.hpp
@@ -1,0 +1,92 @@
+#include <emscripten.h>
+
+namespace duckdb {
+
+struct WasmResultInner {
+  idx_t status;
+  std::string reason;
+  std::string body;
+};
+struct WasmResult {
+  operator bool() { return true; }
+  WasmResultInner *operator->() { return &_inner; }
+  WasmResultInner _inner;
+};
+struct WasmClient {
+  WasmResult Get(string path) {
+    WasmResult res;
+
+    char *exe = NULL;
+    exe = (char *)EM_ASM_PTR(
+        {
+          var url = (UTF8ToString($0));
+          if (typeof XMLHttpRequest === "undefined") {
+            return 0;
+          }
+          const xhr = new XMLHttpRequest();
+          xhr.open("GET", url, false);
+          xhr.responseType = "arraybuffer";
+          xhr.send(null);
+          if (xhr.status != 200)
+            return 0;
+          var uInt8Array = xhr.response;
+
+          var len = uInt8Array.byteLength;
+          var fileOnWasmHeap = _malloc(len + 4);
+
+          var properArray = new Uint8Array(uInt8Array);
+
+          for (var iii = 0; iii < len; iii++) {
+            Module.HEAPU8[iii + fileOnWasmHeap + 4] = properArray[iii];
+            }
+            var LEN123 = new Uint8Array(4);
+            LEN123[0] = len % 256;
+            len -= LEN123[0];
+            len /= 256;
+            LEN123[1] = len % 256;
+            len -= LEN123[1];
+            len /= 256;
+            LEN123[2] = len % 256;
+            len -= LEN123[2];
+            len /= 256;
+            LEN123[3] = len % 256;
+            len -= LEN123[3];
+            len /= 256;
+            Module.HEAPU8.set(LEN123, fileOnWasmHeap);
+		console.log(properArray);
+            return fileOnWasmHeap;
+        },
+        path.c_str());
+
+    if (!exe) {
+      res._inner.status = 404;
+      res._inner.reason = "Something went quack in Wasm land!";
+    } else {
+      res._inner.status = 200;
+      uint64_t LEN = 0;
+      LEN *= 256;
+      LEN += ((uint8_t *)exe)[3];
+      LEN *= 256;
+      LEN += ((uint8_t *)exe)[2];
+      LEN *= 256;
+      LEN += ((uint8_t *)exe)[1];
+      LEN *= 256;
+      LEN += ((uint8_t *)exe)[0];
+      res._inner.body = string(exe + 4, LEN);
+      free(exe);
+    }
+
+    return res;
+  }
+};
+
+static std::pair<WasmClient, std::string>
+SetupHttpClient(const std::string &url) {
+  WasmClient x;
+  return std::make_pair(std::move(x), url);
+}
+
+static void HandleHttpError(const WasmResult &res,
+                            const std::string &request_type) {}
+
+} // namespace duckdb

--- a/src/webmacro_extension.cpp
+++ b/src/webmacro_extension.cpp
@@ -10,12 +10,18 @@
 #include <duckdb/parser/parsed_data/create_scalar_function_info.hpp>
 #include "duckdb/common/exception/http_exception.hpp"
 
+#include "yyjson.hpp"
+
+#ifdef EMSCRIPTEN
+#include "wasm_httplib_replacement.hpp"
+#else
 #define CPPHTTPLIB_OPENSSL_SUPPORT
 #include "httplib.hpp"
-#include "yyjson.hpp"
+#endif
 
 namespace duckdb {
 
+#ifndef EMSCRIPTEN
 // Helper function to setup HTTP client
 static std::pair<duckdb_httplib_openssl::Client, std::string> SetupHttpClient(const std::string &url) {
     std::string scheme, domain, path;
@@ -59,7 +65,7 @@ static void HandleHttpError(const duckdb_httplib_openssl::Result &res, const std
     }
     throw std::runtime_error(err_message);
 }
-
+#endif
 
 static bool ContainsMacroDefinition(const std::string &content) {
     std::string upper_content = StringUtil::Upper(content);


### PR DESCRIPTION
Idea is for `wasm_httplib_replacement.hpp` (or a less hacky version of it) to be part of duckdb/duckdb for 1.2, and expose a subset of HttpLib interface.

This will not, as of now, work in DuckDB-Wasm + node, I have the code also there but this is good enough to get started.

This is a simpler problem than https://github.com/evidence-dev/duckdb_gsheets/issues/35, where a slightly more complex API needs to be mocked.

I have tested this in limited ways locally, and error detection / handling should likely improve (HandleHttpError just do nothing).

Demo:
![image](https://github.com/user-attachments/assets/8c76c5c5-e83d-4455-ba4a-58544e0feb85)
