### PR TITLE
Wasm httplib replacement2

### DIFF
--- a/src/include/wasm_httplib_replacement.hpp
+++ b/src/include/wasm_httplib_replacement.hpp
@@ -1,4 +1,5 @@
 #include <emscripten.h>
+#include "duckdb/common/exception.hpp"
 
 namespace duckdb {
 
@@ -26,7 +27,11 @@ struct WasmClient {
           const xhr = new XMLHttpRequest();
           xhr.open("GET", url, false);
           xhr.responseType = "arraybuffer";
-          xhr.send(null);
+          try {
+             xhr.send(null);
+          } catch {
+             return 0;
+          }
           if (xhr.status != 200)
             return 0;
           var uInt8Array = xhr.response;
@@ -59,8 +64,8 @@ struct WasmClient {
         path.c_str());
 
     if (!exe) {
-      res._inner.status = 404;
-      res._inner.reason = "Something went quack in Wasm land!";
+      res._inner.status = 400;
+      res._inner.reason = "Unknown error, something went quack in Wasm land! Please consult the console and or the docs at https://duckdb.org/community_extensions/extensions/webmacro";
     } else {
       res._inner.status = 200;
       uint64_t LEN = 0;
@@ -87,6 +92,8 @@ SetupHttpClient(const std::string &url) {
 }
 
 static void HandleHttpError(const WasmResult &res,
-                            const std::string &request_type) {}
+                            const std::string &request_type) {
+  throw HTTPException("Unknown problem while perfoming XMLHttpRequest");
+}
 
 } // namespace duckdb

--- a/src/webmacro_extension.cpp
+++ b/src/webmacro_extension.cpp
@@ -168,7 +168,7 @@ static void LoadMacroFromUrlFunction(DataChunk &args, ExpressionState &state, Ve
                 }
 
                 if (res->status != 200) {
-                    throw std::runtime_error("HTTP error " + std::to_string(res->status) + ": " + res->reason);
+                    throw HTTPException(std::to_string(res->status) + ": " + res->reason);
                 }
 
                 // Get the SQL content
@@ -208,7 +208,9 @@ static void LoadMacroFromUrlFunction(DataChunk &args, ExpressionState &state, Ve
 
                 return StringVector::AddString(result, "Successfully loaded macro: " + macro_name);
 
-            } catch (std::exception &e) {
+            } catch (duckdb::HTTPException &e) {
+		throw;
+	    } catch (std::exception &e) {
                 std::string error_msg = "Error: " + std::string(e.what());
                 throw std::runtime_error(error_msg);
             }


### PR DESCRIPTION
This improves the codepath for problematic cases where JavaScript request would fail / throw.


There is a change outside of Wasm: using HTTPException instead of std::runtime_error.
They should behave about the same (since HTTPException is a std::runtime_error), but be rendered somehow better.

Error message in case of CORS errors is now:
```
SELECT load_macro_from_url('https://gist.github.com/lmangani/518215a68e674ac662537d518799b893/raw/5f305480fdd7468f4ecda3686011bab8e8e711bf/bsky.sql') as res;
HTTP Error: 400: Unknown error, something went quack in Wasm land! Please consult the console and or the docs at https://duckdb.org/community_extensions/extensions/webmacro
```